### PR TITLE
Use permanent link instead of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [View the application](https://trends.now.sh)
 
-Trends is an ultra high performance progressive web application built with React + Next.js and GraphQL. Trends pushes the performance needle forward by only using React on the server and then using the absolute minimum client side code to register a service worker totaling around [~15 lines of code](https://github.com/hanford/trends/blob/master/pages/_document.js#L69)
+Trends is an ultra high performance progressive web application built with React + Next.js and GraphQL. Trends pushes the performance needle forward by only using React on the server and then using the absolute minimum client side code to register a service worker totaling around [~15 lines of code](https://github.com/hanford/trends/blob/0c25fbd7f3127ad9007ea9f12e7449054129c2aa/pages/_document.js#L86)
 
 Checkout the perfect performance audit 💯
 <img src='https://github.com/hanford/trends/blob/master/audit.jpg' alt='perf audit' width='600px' />
@@ -23,7 +23,7 @@ Checkout the perfect performance audit 💯
 - Progressive web app
   - offline
   - install prompts on supported platforms
-- [15 lines of client side code](https://github.com/hanford/trends/blob/master/pages/_document.js#L69)
+- [15 lines of client side code](https://github.com/hanford/trends/blob/0c25fbd7f3127ad9007ea9f12e7449054129c2aa/pages/_document.js#L86)
 - Server side rendering
 - GraphQL
 - Next.js


### PR DESCRIPTION
I found some link in the README was broken since it's been pointing to `master` branch like `https://github.com/hanford/trends/blob/master/pages/_document.js#L69`.

![image](https://user-images.githubusercontent.com/1811616/46244548-686dfd80-c41b-11e8-821c-e7f3054c8aac.png)

I just fixed them by replacing a permanent link.

(Feel free to close if you think it's not a problem!)