### PR TITLE
Fix failing now.sh deploy

### DIFF
--- a/www/next.config.js
+++ b/www/next.config.js
@@ -1,23 +1,21 @@
-const withOffline = moduleExists('next-offline')
-  ? require('next-offline')
-  : {};
+const withOffline = moduleExists("next-offline") ? require("next-offline") : {};
 
-const isDev = process.env.NODE_ENV !== 'production'
+const isDev = process.env.NODE_ENV !== "production";
 
 const nextConfig = {
   publicRuntimeConfig: {
-    googleAnalytics: isDev ? '' : 'UA-45226320-5',
+    googleAnalytics: isDev ? "" : "UA-45226320-5",
     isDev
   },
   dontAutoRegisterSW: true,
   workboxOpts: {
-    swDest: 'static/sw.js',
+    swDest: "static/sw.js",
     runtimeCaching: [
       {
         urlPattern: /^https?.*/,
-        handler: 'networkFirst',
+        handler: "networkFirst",
         options: {
-          cacheName: 'https-calls',
+          cacheName: "https-calls",
           networkTimeoutSeconds: 15,
           expiration: {
             maxEntries: 150,
@@ -29,12 +27,17 @@ const nextConfig = {
         }
       }
     ]
+  },
+  webpack: config => {
+    // .mjs before .js for apollo and graphql (fixing failing now.sh deploy)
+    config.resolve.extensions = [".wasm", ".mjs", ".js", ".jsx", ".json"];
+    return config;
   }
 };
 
-module.exports = moduleExists('next-offline')
+module.exports = moduleExists("next-offline")
   ? withOffline(nextConfig)
-  : nextConfig
+  : nextConfig;
 
 function moduleExists(name) {
   try {


### PR DESCRIPTION
Was experiencing an issue when trying to deploy this repo using latest now.sh version (12.1.9).
Once I saw this error it reminded me of a previous graphql error:  https://github.com/graphql/graphql-js/issues/1272#issuecomment-377384574.

For some reason when building next.js locally (for dev or prod) it doesn't happen. It happens only when  on now.sh build infrastructure.

The prettier setup on pre commit hook is the one causing all these formatting changes.


### This is the error
```
441Z  > Emitted warnings from webpack
2018-12-09T03:21:46.442Z  ModuleDependencyWarning: Critical dependency: the request of a dependency is an expression
                              at Compilation.reportDependencyErrorsAndWarnings (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1359:23)
                              at Compilation.finish (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1165:9)
                              at hooks.make.callAsync.err (/tmp/3b331899/node_modules/webpack/lib/Compiler.js:544:17)
                              at _err0 (eval at create (/tmp/3b331899/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:11:1)
                              at Promise.all.then (/tmp/3b331899/node_modules/webpack/lib/DynamicEntryPlugin.js:74:20)
                              at <anonymous>
                              at process._tickCallback (internal/process/next_tick.js:188:7)
                              at CommonJsRequireContextDependency.getWarnings (/tmp/3b331899/node_modules/webpack/lib/dependencies/ContextDependency.js:40:18)
                              at Compilation.reportDependencyErrorsAndWarnings (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1354:24)
                              at Compilation.finish (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1165:9)
                             
2018-12-09T03:21:46.448Z  ModuleDependencyError: Can't reexport the named export 'BREAK' from non EcmaScript module (only default export is available)
                              at Compilation.reportDependencyErrorsAndWarnings (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1368:21)
                              at Compilation.finish (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1165:9)
                              at hooks.make.callAsync.err (/tmp/3b331899/node_modules/webpack/lib/Compiler.js:544:17)
                              at _err0 (eval at create (/tmp/3b331899/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:11:1)
                              at Promise.all.then (/tmp/3b331899/node_modules/webpack/lib/DynamicEntryPlugin.js:74:20)
                              at <anonymous>
                              at process._tickCallback (internal/process/next_tick.js:188:7)
                              at HarmonyExportImportedSpecifierDependency._getErrors (/tmp/3b331899/node_modules/webpack/lib/dependencies/HarmonyExportImportedSpecifierDependency.js:360:6)
                              at HarmonyExportImportedSpecifierDependency.getErrors (/tmp/3b331899/node_modules/webpack/lib/dependencies/HarmonyExportImportedSpecifierDepe
2018-12-09T03:21:46.448Z  ack/lib/Compiler.js:544:17)
                              at _err0 (eval at create (/tmp/3b331899/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:11:1)
                              at Promise.all.then (/tmp/3b331899/node_modules/webpack/lib/DynamicEntryPlugin.js:74:20)
                              at <anonymous>
                              at process._tickCallback (internal/process/next_tick.js:188:7) ModuleDependencyError: Can't reexport the named export 'SchemaMetaFieldDef' from non EcmaScript module (only default export is available)
                              at Compilation.reportDependencyErrorsAndWarnings (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1368:21)
                              at Compilation.finish (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1165:9)
                              at hooks.make.callAsync.err (/tmp/3b331899/node_modules/webpack/lib/Compiler.js:544:17)
                              at _err0 (eval at create (/tmp/3b331899/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:11:1)
                              at Promise.all.then (/tmp/3b331899/node_modules/webpack/lib/DynamicEntryPlugin.js:74:20)
                              at <anonymous>
                              at process._tickCallback (internal/pr
2018-12-09T03:21:46.448Z  lation.reportDependencyErrorsAndWarnings (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1363:22)
                              at Compilation.finish (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1165:9)
                              at hooks.make.callAsync.err (/tmp/3b331899/node_modules/webpack/lib/Compiler.js:544:17)
                              at _err0 (eval at create (/tmp/3b331899/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:11:1)
                              at Promise.all.then (/tmp/3b331899/node_modules/webpack/lib/DynamicEntryPlugin.js:74:20)
                              at <anonymous>
                              at process._tickCallback (internal/process/next_tick.js:188:7) ModuleDependencyError: Can't reexport the named export 'assertType' from non EcmaScript module (only default export is available)
                              at Compilation.reportDependencyErrorsAndWarnings (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1368:21)
                              at Compilation.finish (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1165:9)
                              at hooks.make.callAsync.err (/tmp/3b331899/node_modules/webpack/lib/Compiler.js:544:17)
                              at _err0 (eva
2018-12-09T03:21:46.448Z   HarmonyExportImportedSpecifierDependency.getErrors (/tmp/3b331899/node_modules/webpack/lib/dependencies/HarmonyExportImportedSpecifierDependency.js:338:16)
                              at Compilation.reportDependencyErrorsAndWarnings (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1363:22)
                              at Compilation.finish (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1165:9)
                              at hooks.make.callAsync.err (/tmp/3b331899/node_modules/webpack/lib/Compiler.js:544:17)
                              at _err0 (eval at create (/tmp/3b331899/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:11:1)
                              at Promise.all.then (/tmp/3b331899/node_modules/webpack/lib/DynamicEntryPlugin.js:74:20)
                              at <anonymous>
                              at process._tickCallback (internal/process/next_tick.js:188:7) ModuleDependencyError: Can't reexport the named export 'isExecutableDefinitionNode' from non EcmaScript module (only default export is available)
                              at Compilation.reportDependencyErrorsAndWarnings (/tmp/3b331899/node_modules/webpack/lib/Compilation.js:1368:21)
                              at Compil
2018-12-09T03:21:46.484Z  error Command failed with exit code 1.
2018-12-09T03:21:46.484Z  info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
2018-12-09T03:21:46.490Z  patching https://api-sfo1.zeit.co/v2/now/deployments/dpl_FngQXbzJU4ZEZQHJkdg45PFuK4xP/builds/bld_hfc02q4fq with {"readyState":"ERROR","errorCode":"BUILD_FAILED"}
2018-12-09T03:21:46.550Z  { Error: Exited with 1
                              at ChildProcess.child.on (/tmp/utils/node_modules/@now/build-utils/fs/run-user-scripts.js:11:16)
                              at emitTwo (events.js:126:13)
                              at ChildProcess.emit (events.js:214:7)
                              at maybeClose (internal/child_process.js:925:16)
                              at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5) reported: true }
```